### PR TITLE
Fix: correct the h3 tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,5 +4,6 @@
 <!-- Story2: Changed the two paragraphs from pp which is not a valid HTML element to the p element -->
 <p>My name is Camperbot and I love learning new things.</p>
 
-<h3>Background and Interests<h3/>
+<!-- Story3: Made the slash before the h3 in the closing tag. -->
+<h3>Background and Interests</h3>
 <p>I enjoy solving puzzles.</p>


### PR DESCRIPTION
Correct the closing tag of the `<h3>` element to have the `\` before, not after the closing tag.